### PR TITLE
Port of MDL-52186

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -74,11 +74,12 @@ function enrol_metabulk_sync($listofcourses = null, $verbose = false, $userid = 
     $sql = "SELECT pue.userid, e.id as enrolid, pue.status
             FROM {user_enrolments} pue
             JOIN {enrol} pe ON (pe.id = pue.enrolid AND pe.enrol <> 'metabulk' AND pe.enrol $enabled)
-            JOIN {enrol} e ON (e.enrol = 'metabulk' $onecourse)
+            JOIN {enrol} e ON (e.enrol = 'metabulk' AND e.status = :enrolstatus $onecourse)
             JOIN {enrol_metabulk} m ON (m.enrolid = e.id AND m.courseid = pe.courseid)
             JOIN {user} u ON (u.id = pue.userid AND u.deleted = 0)
         LEFT JOIN {user_enrolments} ue ON (ue.enrolid = e.id AND ue.userid = pue.userid)
             WHERE ue.id IS NULL $oneuser";
+    $params['enrolstatus'] = ENROL_INSTANCE_ENABLED;
 
     $rs = $DB->get_recordset_sql($sql, $params);
     foreach ($rs as $ue) {


### PR DESCRIPTION
Hi,

I've detected that enrol_metabulk plugin is also affected by [MDL-52186](https://tracker.moodle.org/browse/MDL-52186), so I've applied that fix here and checked it fixes the issue:

https://github.com/moodle/moodle/commit/b62bebbf1c9cb1e08c9d95a1d8baa6d4a2dc70db#diff-3b07a91899c1565b7a966e5d9d8b2457

